### PR TITLE
feat: add Bernini in-context conditioning for Wan models

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ After installing, open ComfyUI and find the bundled example workflows in the **T
 
 ### v1.0.3
 
+- **[Bernini Temporary Solution]** Added `Bernini conditioning` and `Bernini Model Patch` nodes, providing a temporary solution before ComfyUI officially supports Bernini
 - **[Timeline Editor: UI Mode]** Fixed an issue where `node height` would reset to the default value when `canvas refresh` or `resolution option` was switched
 - **[Timeline Editor: UI Mode]** Fixed an issue where clip content could not be edited in some cases when using `Overall Edit` prompt mode
 - **[Timeline Editor: UI Mode]** Fixed the issue where nodes and track heights didn't adapt automatically; added `Clone Clip` to the right-click menu for better compatibility with wan2's `berinini` and `LTX2.3 R2V`

--- a/README_CN.md
+++ b/README_CN.md
@@ -25,6 +25,7 @@ git clone https://github.com/yolain/ComfyUI-Easy-Media.git
 
 ### v1.0.3
 
+- **【Bernini临时方案】** 添加了`Bernini conditioning`和 `Bernini Model Patch`节点, 在未更新到ComfyUI支持Bernini时，提供了一个暂时方案
 - **【时间线编辑器：UI模式】** 修复`节点高度`在`画布刷新`和`分辨率选项`切换时会被恢复成默认值的bug
 - **【时间线编辑器：UI模式】** 修复`整体编辑`提示词模式下，有些情况下不能编辑片段内容的bug
 - **【时间线编辑器：UI模式】** 修复节点和轨道高度自适应的问题，右键菜单新增`克隆片段`，以方便 wan2的`berinini`和 `LTX2.3 R2V` 使用

--- a/__init__.py
+++ b/__init__.py
@@ -46,7 +46,7 @@ else:
 class EasyMediaExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[io.ComfyNode]]:
-        return [
+        nodes = [
             TimelineEditor,
             TimelineInfoOutput,
             TimelineSegmentOutput,
@@ -54,6 +54,8 @@ class EasyMediaExtension(ComfyExtension):
             ImageIndexesToIntList,
             MakeImageList,
             MakeAudioList,
+            # Wan
+            BerniniModelPatch,
             # LTXV
             LTXVAddGuidesFromBatchIndexes,
             LTXVMakeRefVideo,
@@ -62,6 +64,10 @@ class EasyMediaExtension(ComfyExtension):
             EasyMergeVideos,
             EasyMergeVideosFromPaths,
         ]
-
+        try:
+            from comfy_extras.nodes_bernini import BerniniConditioning as CoreBerniniConditioning
+        except ImportError:
+            nodes.extend([BerniniConditioning])
+        return nodes
 async def comfy_entrypoint() -> EasyMediaExtension:
     return EasyMediaExtension()

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -1,3 +1,4 @@
 from .basic import *
 from .ltxv import *
 from .video import *
+from .wan import *

--- a/nodes/wan.py
+++ b/nodes/wan.py
@@ -33,15 +33,19 @@ class BerniniModelPatch(io.ComfyNode):
 
     @classmethod
     def execute(cls, model: io.Model.Type) -> io.NodeOutput:
-        from ..utils.bernini import bind_bernini_conds, bernini_diffusion_wrapper
-        m = model.clone()
-        bind_bernini_conds(m)
-        m.add_wrapper_with_key(
-            comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL,
-            "bernini_forward_wrapper",
-            bernini_diffusion_wrapper,
-        )
-        return io.NodeOutput(m)
+        try:
+            from comfy_extras.nodes_bernini import BerniniConditioning as CoreBerniniConditioning
+            return io.NodeOutput(model)
+        except ImportError:
+            from ..utils.bernini import bind_bernini_conds, bernini_forward_wrapper
+            m = model.clone()
+            bind_bernini_conds(m)
+            m.add_wrapper_with_key(
+                comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL,
+                "bernini_forward_wrapper",
+                bernini_forward_wrapper,
+            )
+            return io.NodeOutput(m)
 
 # code based on https://github.com/Comfy-Org/ComfyUI/pull/14216
 class BerniniConditioning(io.ComfyNode):

--- a/nodes/wan.py
+++ b/nodes/wan.py
@@ -1,0 +1,140 @@
+import torch
+import comfy.patcher_extension
+import comfy.model_management
+import comfy.utils
+import node_helpers
+from comfy_api.latest import io
+
+def _resize_long_edge(image, max_size, stride=16):
+    """Resize (preserve aspect) so the long edge <= max_size, then snap each side to `stride`
+    (snapping can nudge a side up/down by < stride, so it never scales up by more than that)."""
+    h, w = image.shape[1], image.shape[2]
+    scale = min(max_size / max(h, w), 1.0)
+    nh = max(stride, round(h * scale / stride) * stride)
+    nw = max(stride, round(w * scale / stride) * stride)
+    return comfy.utils.common_upscale(image[:, :, :, :3].movedim(-1, 1), nw, nh, "area", "disabled").movedim(1, -1)
+
+class BerniniModelPatch(io.ComfyNode):
+    """Attach Bernini support to a Wan model through ComfyUI model wrappers."""
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="BerniniModelPatch",
+            display_name="Bernini Model Patch",
+            category="model_patches/video_models",
+            description="Adds Bernini in-context latent support to a Wan model using ComfyUI model wrappers.",
+            inputs=[
+                io.Model.Input("model"),
+            ],
+            outputs=[
+                io.Model.Output(display_name="model"),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, model: io.Model.Type) -> io.NodeOutput:
+        from ..utils.bernini import bind_bernini_conds, bernini_diffusion_wrapper
+        m = model.clone()
+        bind_bernini_conds(m)
+        m.add_wrapper_with_key(
+            comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL,
+            "bernini_forward_wrapper",
+            bernini_diffusion_wrapper,
+        )
+        return io.NodeOutput(m)
+
+# code based on https://github.com/Comfy-Org/ComfyUI/pull/14216
+class BerniniConditioning(io.ComfyNode):
+    """Bernini in-context conditioning for a Wan2.2-A14B model.
+
+    Attaches the VAE-encoded source video / reference images to the conditioning
+    an ordered list of clean latents (source video first, then each reference image),
+    which the Wan model appends as extra tokens with per-stream source_id rope.
+
+    The task is inferred from which inputs are connected:
+      (nothing)                  -> t2v
+      source_video               -> v2v
+      source_video + ref images  -> rv2v
+      ref images only            -> r2v   (each kept at native aspect)
+      source_video + ref_video   -> video insertion / "ads2v"
+
+    source_video is the edit base / canvas (resized to width x height).
+    reference_video is moving content to composite in (e.g. a clip to play on a
+    screen), kept at its native aspect like the reference images. Streams are
+    ordered source_video, reference_video, then reference_images -> source_id
+    1, 2, 3... matching the reference repo's [base, content, refs].
+    """
+
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="BerniniConditioning",
+            display_name="Bernini Conditioning",
+            category="conditioning/video_models",
+            description="Conditioning node for Bernini in-context video/image conditioning. Attach source video and/or reference images to the positive/negative conditioning, "
+                        "which the Wan model will append as extra tokens with per-stream source_id rope.",
+            inputs=[
+                io.Conditioning.Input("positive"),
+                io.Conditioning.Input("negative"),
+                io.Vae.Input("vae"),
+                io.Int.Input("width", default=832, min=16, max=8192, step=16),
+                io.Int.Input("height", default=480, min=16, max=8192, step=16),
+                io.Int.Input("length", default=81, min=1, max=8192, step=4),
+                io.Int.Input("batch_size", default=1, min=1, max=4096),
+                io.Image.Input("source_video", optional=True, tooltip=(
+                    "Source video to edit/restyle (task v2v or rv2v). Resized to width/height and trimmed to length. Acts as the edit base / canvas.")),
+                io.Image.Input("reference_video", optional=True, tooltip=(
+                    "Moving content to composite into the source video (video insertion / ads2v),"
+                    "e.g. a clip to play on a screen. Kept at native aspect (long edge capped at ref_max_size), trimmed to length.")),
+                io.Autogrow.Input("reference_images", optional=True,
+                    template=io.Autogrow.TemplatePrefix(
+                        input=io.Image.Input("reference_image", tooltip=(
+                            "A reference image injected as an in-context token (task r2v or rv2v).")),
+                        prefix="reference_image_", min=0, max=8),
+                    tooltip=(
+                        "Reference image(s) injected as in-context tokens (task r2v or rv2v). Each slot is "
+                        "encoded independently at its own native aspect ratio (long edge capped at "
+                        "ref_max_size), so connect mixed-size references to separate slots.")),
+                io.Int.Input("ref_max_size", default=848, min=16, max=8192, step=16, optional=True, tooltip=(
+                    "Max size for the long edge of reference_video and reference_images. Resized with preserved aspect ratio and snapped to 16px (snapping may nudge a side by <16px).")),
+            ],
+            outputs=[
+                io.Conditioning.Output(display_name="positive"),
+                io.Conditioning.Output(display_name="negative"),
+                io.Latent.Output(display_name="latent"),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, positive, negative, vae, width, height, length, batch_size,
+                source_video=None, reference_video=None, reference_images=None, ref_max_size=848) -> io.NodeOutput:
+        latent = torch.zeros([batch_size, 16, ((length - 1) // 4) + 1, height // 8, width // 8],
+                             device=comfy.model_management.intermediate_device())
+
+        # Ordered list of condition streams -> source_id by list order:
+        # source_video (1), reference_video (2), reference_images (3, 4, ...).
+        context = []
+        if source_video is not None:
+            vid = comfy.utils.common_upscale(source_video[:length, :, :, :3].movedim(-1, 1), width, height, "area", "center").movedim(1, -1)
+            context.append(vae.encode(vid[:, :, :, :3]))
+
+        if reference_video is not None:
+            ref_vid = _resize_long_edge(reference_video[:length], ref_max_size)  # moving content, native aspect
+            context.append(vae.encode(ref_vid[:, :, :, :3]))
+
+        # reference_images is an autogrow dict {reference_image_0: IMAGE, ...}; each slot is a
+        # separate stream at its own native aspect (a multi-image batch in one slot -> one stream per frame).
+        if reference_images:
+            for name in sorted(reference_images):
+                imgs = reference_images[name]
+                if imgs is None:
+                    continue
+                for i in range(imgs.shape[0]):
+                    img = _resize_long_edge(imgs[i:i + 1], ref_max_size)  # native aspect per ref
+                    context.append(vae.encode(img[:, :, :, :3]))
+
+        if context:
+            positive = node_helpers.conditioning_set_values(positive, {"context_latents": context})
+            negative = node_helpers.conditioning_set_values(negative, {"context_latents": context})
+
+        return io.NodeOutput(positive, negative, {"samples": latent})

--- a/utils/bernini.py
+++ b/utils/bernini.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+from typing import Any
+
+import types
+import torch
+
+
+def _rope_encode_with_source_id(
+    wan_model,
+    t,
+    h,
+    w,
+    *,
+    t_start=0,
+    steps_t=None,
+    steps_h=None,
+    steps_w=None,
+    device=None,
+    dtype=None,
+    transformer_options=None,
+    source_id=0,
+):
+    freqs = wan_model.rope_encode(
+        t,
+        h,
+        w,
+        t_start=t_start,
+        steps_t=steps_t,
+        steps_h=steps_h,
+        steps_w=steps_w,
+        device=device,
+        dtype=dtype,
+        transformer_options=transformer_options or {},
+    )
+    if source_id:
+        from comfy.ldm.flux.math import rope
+
+        d = wan_model.dim // wan_model.num_heads
+        pos = torch.tensor([[float(source_id)]], device=freqs.device, dtype=torch.float32)
+        id_rot = rope(pos, d, wan_model.rope_embedder.theta).reshape(1, 1, 1, d // 2, 2, 2).to(freqs.dtype)
+        freqs = torch.einsum("...ij,...jk->...ik", freqs, id_rot)
+    return freqs
+
+
+def _bernini_forward_orig(
+    wan_model,
+    x,
+    t,
+    context,
+    *,
+    clip_fea=None,
+    freqs=None,
+    transformer_options=None,
+    **kwargs,
+):
+    import comfy.ldm.wan.model as wan_model_module
+
+    if transformer_options is None:
+        transformer_options = {}
+
+    x = wan_model.patch_embedding(x.float()).to(x.dtype)
+    grid_sizes = x.shape[2:]
+    transformer_options["grid_sizes"] = grid_sizes
+    x = x.flatten(2).transpose(1, 2)
+
+    e = wan_model.time_embedding(
+        wan_model_module.sinusoidal_embedding_1d(wan_model.freq_dim, t.flatten()).to(dtype=x[0].dtype)
+    )
+    e = e.reshape(t.shape[0], -1, e.shape[-1])
+    e0 = wan_model.time_projection(e).unflatten(2, (6, wan_model.dim))
+
+    full_ref = None
+    if wan_model.ref_conv is not None:
+        full_ref = kwargs.get("reference_latent", None)
+        if full_ref is not None:
+            full_ref = wan_model.ref_conv(full_ref).flatten(2).transpose(1, 2)
+            x = torch.concat((full_ref, x), dim=1)
+
+    context_latents = kwargs.get("context_latents", None)
+    main_len = x.shape[1]
+    if context_latents is not None:
+        for lat in context_latents:
+            cl = wan_model.patch_embedding(lat.float().to(x.device)).to(x.dtype).flatten(2).transpose(1, 2)
+            x = torch.cat([x, cl], dim=1)
+
+    context = wan_model.text_embedding(context)
+
+    context_img_len = None
+    if clip_fea is not None:
+        if wan_model.img_emb is not None:
+            context_clip = wan_model.img_emb(clip_fea)
+            context = torch.concat([context_clip, context], dim=1)
+        context_img_len = clip_fea.shape[-2]
+
+    patches_replace = transformer_options.get("patches_replace", {})
+    blocks_replace = patches_replace.get("dit", {})
+    transformer_options["total_blocks"] = len(wan_model.blocks)
+    transformer_options["block_type"] = "double"
+    for i, block in enumerate(wan_model.blocks):
+        transformer_options["block_index"] = i
+        if ("double_block", i) in blocks_replace:
+
+            def block_wrap(args):
+                return {
+                    "img": block(
+                        args["img"],
+                        context=args["txt"],
+                        e=args["vec"],
+                        freqs=args["pe"],
+                        context_img_len=context_img_len,
+                        transformer_options=args["transformer_options"],
+                    )
+                }
+
+            out = blocks_replace[("double_block", i)](
+                {
+                    "img": x,
+                    "txt": context,
+                    "vec": e0,
+                    "pe": freqs,
+                    "transformer_options": transformer_options,
+                },
+                {"original_block": block_wrap},
+            )
+            x = out["img"]
+        else:
+            x = block(
+                x,
+                e=e0,
+                freqs=freqs,
+                context=context,
+                context_img_len=context_img_len,
+                transformer_options=transformer_options,
+            )
+
+    x = wan_model.head(x, e)
+
+    if context_latents is not None:
+        x = x[:, :main_len]
+
+    if full_ref is not None:
+        x = x[:, full_ref.shape[1] :]
+
+    return wan_model.unpatchify(x, grid_sizes)
+
+def bind_bernini_conds(model):
+    import comfy.conds
+
+    base_model = model.model
+    if getattr(base_model, "_easy_media_bernini_conds", False):
+        return
+
+    orig_extra_conds = base_model.extra_conds
+    orig_resize_cond = base_model.resize_cond_for_context_window
+
+    def extra_conds(self, **kwargs):
+        out = orig_extra_conds(**kwargs)
+        context_latents = kwargs.get("context_latents", None)
+        if context_latents is not None:
+            out["context_latents"] = comfy.conds.CONDList([self.process_latent_in(lat) for lat in context_latents])
+        return out
+
+    def resize_cond_for_context_window(self, cond_key, cond_value, window, x_in, device, retain_index_list=[]):
+        if cond_key == "context_latents" and isinstance(getattr(cond_value, "cond", None), list):
+            dim = window.dim
+            out = []
+            for lat in cond_value.cond:
+                if lat.ndim > dim and lat.shape[dim] > 1 and lat.shape[dim] == x_in.shape[dim]:
+                    idx = tuple([slice(None)] * dim + [window.index_list])
+                    out.append(lat[idx].to(device))
+                else:
+                    out.append(lat.to(device))
+            return cond_value._copy_with(out)
+        return orig_resize_cond(cond_key, cond_value, window, x_in, device, retain_index_list=retain_index_list)
+
+    base_model.extra_conds = types.MethodType(extra_conds, base_model)
+    base_model.resize_cond_for_context_window = types.MethodType(resize_cond_for_context_window, base_model)
+    base_model._easy_media_bernini_conds = True
+
+def bernini_diffusion_wrapper(
+    executor,
+    x,
+    timestep,
+    context,
+    clip_fea=None,
+    time_dim_concat=None,
+    transformer_options=None,
+    **kwargs,
+):
+    import comfy.ldm.common_dit
+
+    context_latents = kwargs.get("context_latents", None)
+    if context_latents is None:
+        return executor(x, timestep, context, clip_fea, time_dim_concat, transformer_options, **kwargs)
+
+    if transformer_options is None:
+        transformer_options = {}
+
+    wan_model = executor.class_obj
+    _, _, t, h, w = x.shape
+    x = comfy.ldm.common_dit.pad_to_patch_size(x, wan_model.patch_size)
+
+    t_len = t
+    if time_dim_concat is not None:
+        time_dim_concat = comfy.ldm.common_dit.pad_to_patch_size(time_dim_concat, wan_model.patch_size)
+        x = torch.cat([x, time_dim_concat], dim=2)
+        t_len = x.shape[2]
+
+    if wan_model.ref_conv is not None and "reference_latent" in kwargs:
+        t_len += 1
+
+    freqs = wan_model.rope_encode(t_len, h, w, device=x.device, dtype=x.dtype, transformer_options=transformer_options)
+    padded_context_latents = [
+        comfy.ldm.common_dit.pad_to_patch_size(lat, wan_model.patch_size) for lat in context_latents
+    ]
+    for i, lat in enumerate(padded_context_latents):
+        freqs = torch.cat(
+            [
+                freqs,
+                _rope_encode_with_source_id(
+                    wan_model,
+                    lat.shape[-3],
+                    lat.shape[-2],
+                    lat.shape[-1],
+                    device=x.device,
+                    dtype=x.dtype,
+                    transformer_options=transformer_options,
+                    source_id=i + 1,
+                ),
+            ],
+            dim=1,
+        )
+
+    kwargs = {**kwargs, "context_latents": padded_context_latents}
+    out = _bernini_forward_orig(
+        wan_model,
+        x,
+        timestep,
+        context,
+        clip_fea=clip_fea,
+        freqs=freqs,
+        transformer_options=transformer_options,
+        **kwargs,
+    )
+    return out[:, :, :t, :h, :w]

--- a/utils/bernini.py
+++ b/utils/bernini.py
@@ -147,7 +147,7 @@ def bind_bernini_conds(model):
     import comfy.conds
 
     base_model = model.model
-    if getattr(base_model, "_easy_media_bernini_conds", False):
+    if getattr(base_model, "_bernini_conds", False):
         return
 
     orig_extra_conds = base_model.extra_conds
@@ -175,9 +175,9 @@ def bind_bernini_conds(model):
 
     base_model.extra_conds = types.MethodType(extra_conds, base_model)
     base_model.resize_cond_for_context_window = types.MethodType(resize_cond_for_context_window, base_model)
-    base_model._easy_media_bernini_conds = True
+    base_model._bernini_conds = True
 
-def bernini_diffusion_wrapper(
+def bernini_forward_wrapper(
     executor,
     x,
     timestep,


### PR DESCRIPTION
## Summary
Add Bernini in-context video/image conditioning support for Wan models.

### Changes
- **BerniniModelPatch** node — attaches Bernini support to a Wan model via ComfyUI model wrappers
- **BerniniConditioning** node — handles in-context conditioning (t2v, v2v, rv2v, r2v, ads2v)
- **utils/bernini.py** — core implementation with  and 
- Auto-fallback to local implementation when  is unavailable

### Test Plan
- [x] Load workflow with BerniniModelPatch + BerniniConditioning
- [x] Verify Wan model generates with in-context conditioning
- [ ] Test all task types: t2v, v2v, rv2v, r2v, ads2v