### PR TITLE
fix(multitrack): preserve @image/@audio/@video slot media under is_in…

### DIFF
--- a/nodes/basic.py
+++ b/nodes/basic.py
@@ -307,8 +307,13 @@ def _slot_index(slot_name: str | None) -> int:
 
 
 def _unwrap_slot_input(value):
-    if isinstance(value, list) and len(value) == 1 and isinstance(value[0], list):
-        return value[0]
+    # With is_input_list (and lazy inputs), a value can arrive as a tuple or as a
+    # tuple-wrapped list; normalise to a plain list before indexing.
+    if isinstance(value, tuple):
+        value = list(value)
+    if isinstance(value, list) and len(value) == 1 and isinstance(value[0], (list, tuple)):
+        inner = value[0]
+        return list(inner) if isinstance(inner, tuple) else inner
     return value
 
 
@@ -444,9 +449,13 @@ def _resolution_needs_source_dimensions(resolution: str | dict) -> bool:
 def _as_list_input(value) -> list:
     if value is None:
         return []
+    # is_input_list/lazy plumbing can also deliver a tuple (or tuple-wrapped list).
+    if isinstance(value, tuple):
+        value = list(value)
     if isinstance(value, list):
-        if len(value) == 1 and isinstance(value[0], list):
-            return value[0]
+        if len(value) == 1 and isinstance(value[0], (list, tuple)):
+            inner = value[0]
+            return list(inner) if isinstance(inner, tuple) else inner
         return value
     return [value]
 
@@ -1059,9 +1068,18 @@ def _index_slot_image(image_input, slot_name: str | None) -> 'torch.Tensor | Non
     image_input = _unwrap_slot_input(image_input)
     if image_input is None:
         return None
-    candidates = image_input if isinstance(image_input, list) else [image_input]
+    candidates = image_input if isinstance(image_input, (list, tuple)) else [image_input]
     flattened: list[torch.Tensor] = []
     for candidate in candidates:
+        # Tolerate a nested list/tuple of tensors produced by is_input_list plumbing.
+        if isinstance(candidate, (list, tuple)):
+            for sub in candidate:
+                if not isinstance(sub, torch.Tensor):
+                    continue
+                t2 = _normalize_image_tensor(sub)
+                if t2 is not None and not _is_empty_slot_image(t2):
+                    flattened.extend(t2[i:i + 1] for i in range(t2.shape[0]))
+            continue
         if not isinstance(candidate, torch.Tensor):
             continue
         tensor = _normalize_image_tensor(candidate)
@@ -1834,7 +1852,18 @@ class MultiTrackEditor(io.ComfyNode):
             data = build_multitrack_data_from_prompt_override(data, raw_override)
         slot_types = multitrack_slot_media_types(data)
         values = {"image": image, "audio": audio, "video": video}
-        return [media_type for media_type in sorted(slot_types) if values[media_type] is None]
+
+        def _missing_lazy_input(v):
+            # An unevaluated lazy input under is_input_list arrives as (None,) rather
+            # than None; treat None / empty / all-None sequences as missing so the
+            # engine is asked to evaluate it.
+            if v is None:
+                return True
+            if isinstance(v, (list, tuple)):
+                return len(v) == 0 or all(x is None for x in v)
+            return False
+
+        return [media_type for media_type in sorted(slot_types) if _missing_lazy_input(values[media_type])]
 
     @classmethod
     def execute(

--- a/tests/test_slot_input_containers.py
+++ b/tests/test_slot_input_containers.py
@@ -1,0 +1,136 @@
+"""Slot media inputs (@imageN/@audioN/@videoN) must survive the container shapes that
+``is_input_list=True`` (and lazy inputs) can produce at runtime: a plain list, a tuple,
+and single-element list/tuple-wrapped nested containers.
+
+Regression: under the V3 input system an unevaluated lazy slot arrives as ``(None,)``
+rather than ``None`` and, once materialised, slot media can arrive as a tuple. The slot
+indexing helpers only handled ``list``, so the referenced media was silently dropped
+(images fell back to ``t2v``; video indexing returned the wrapper tuple).
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _load_harness():
+    # Load the shared stub harness by path so this works under any pytest import
+    # mode and regardless of whether the tests directory is on sys.path.
+    harness_path = Path(__file__).with_name("test_multitrack_info_output.py")
+    spec = importlib.util.spec_from_file_location("_em_multitrack_harness", harness_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_load_basic_module = _load_harness()._load_basic_module
+
+
+@pytest.fixture(scope="module")
+def basic():
+    return _load_basic_module()
+
+
+def _containers(first, second=None):
+    """Every container shape the input plumbing can hand to a slot indexer."""
+    single = {
+        "list": [first],
+        "tuple": (first,),
+        "nested-list": [[first]],
+        "nested-tuple": ([first],),
+    }
+    if second is None:
+        return single
+    multi = {
+        "list": [first, second],
+        "tuple": (first, second),
+        "nested-list": [[first, second]],
+        "nested-tuple": ([first, second],),
+    }
+    return single, multi
+
+
+def _is_real_image(basic, tensor):
+    return (
+        isinstance(tensor, torch.Tensor)
+        and not basic._is_empty_slot_image(basic._normalize_image_tensor(tensor))
+    )
+
+
+def test_index_slot_image_single(basic):
+    image = torch.rand(1, 480, 832, 3)
+    for label, value in _containers(image).items():
+        result = basic._index_slot_image(value, "image1")
+        assert _is_real_image(basic, result), f"image1 via {label} was dropped"
+
+
+def test_index_slot_image_multi(basic):
+    first, second = torch.rand(1, 480, 832, 3), torch.rand(1, 480, 832, 3)
+    _, multi = _containers(first, second)
+    for label, value in multi.items():
+        result = basic._index_slot_image(value, "image2")
+        assert isinstance(result, torch.Tensor), f"image2 via {label} was dropped"
+        assert result.shape[0] == 1
+
+
+def test_index_slot_image_skips_empty_placeholder(basic):
+    # makeImageList(skip_empty=False) pads unused slots with 1x1 placeholders
+    real = torch.rand(1, 480, 832, 3)
+    empty = torch.zeros(1, 1, 4)
+    result = basic._index_slot_image([real, empty, empty], "image1")
+    assert _is_real_image(basic, result)
+
+
+def test_index_slot_audio_single(basic):
+    audio = {"waveform": torch.zeros(1, 2, 100), "sample_rate": 44100}
+    for label, value in _containers(audio).items():
+        result = basic._index_slot_audio(value, "audio1")
+        assert isinstance(result, dict) and "waveform" in result, f"audio1 via {label}"
+
+
+def test_index_slot_audio_multi(basic):
+    first = {"waveform": torch.zeros(1, 2, 100), "sample_rate": 44100}
+    second = {"waveform": torch.zeros(1, 2, 200), "sample_rate": 44100}
+    _, multi = _containers(first, second)
+    for label, value in multi.items():
+        result = basic._index_slot_audio(value, "audio2")
+        assert result is second, f"audio2 via {label} did not select the second clip"
+
+
+def test_index_slot_video_single(basic):
+    video = object()
+    for label, value in _containers(video).items():
+        result = basic._index_slot_video(value, "video1")
+        assert result is video, f"video1 via {label} returned {type(result).__name__}"
+
+
+def test_index_slot_video_multi(basic):
+    first, second = object(), object()
+    _, multi = _containers(first, second)
+    for label, value in multi.items():
+        result = basic._index_slot_video(value, "video2")
+        assert result is second, f"video2 via {label} did not select the second clip"
+
+
+@pytest.mark.parametrize(
+    "value,expected_len",
+    [
+        ((object(),), 1),
+        (([object(), object()],), 2),
+        ([object()], 1),
+        ([[object(), object()]], 2),
+        (None, 0),
+    ],
+)
+def test_as_list_input_normalises_tuples(basic, value, expected_len):
+    result = basic._as_list_input(value)
+    assert isinstance(result, list)
+    assert len(result) == expected_len
+
+
+def test_unwrap_slot_input_normalises_tuples(basic):
+    item = object()
+    assert basic._unwrap_slot_input((item,)) == [item]
+    assert basic._unwrap_slot_input(([item],)) == [item]
+    assert basic._unwrap_slot_input([item]) == [item]


### PR DESCRIPTION
### Problem

Closes #49. On the current V3 input system, MultiTrackEditor slot media declared with `is_input_list=True, lazy=True` was silently dropped:

- `check_lazy_status` compared an unevaluated input to `None`, but under `is_input_list` it arrives as `(None,)`, so evaluation was never requested;
- the slot-indexing helpers (`_unwrap_slot_input`, `_as_list_input`, `_index_slot_image`) only handled `list`/scalar containers and mis-handled `tuple` and single-element nested containers produced by the input plumbing.

As a result `@imageN/@audioN/@videoN` references in `prompt_override` had no effect (images fell back to `t2v`; video indexing returned the wrapper tuple).

### Changes (`nodes/basic.py`, +33/−6)

1. `_unwrap_slot_input` — accept a `tuple` and a tuple-wrapped nested list, normalising to a plain list (covers image and audio slot indexing).
2. `_as_list_input` — same tuple normalisation (covers video slot indexing via `_index_slot_video`, and `MultiTrackTaskOutput` for all three media).
3. `_index_slot_image` — treat candidates as `list`/`tuple` and recursively flatten a nested list/tuple of tensors, still filtering empty 1×1 placeholders.
4. `check_lazy_status` — treat `None`, an empty sequence, or an all-`None` sequence as missing so the engine is asked to evaluate the corresponding lazy image/audio/video input.

No public API, widget, or workflow format changes; behaviour for existing `list` inputs is unchanged.

### Tests

Add `tests/test_slot_input_containers.py` (13 cases) feeding every container shape the plumbing can produce — plain `list`, `tuple`, single-element nested list/tuple — through all three slot indexers and both helpers, for single and multi-slot selection. It loads the existing `_load_basic_module` stub harness by file path so it works under any pytest import mode.

Targeted run (the multitrack suite plus the new test):
- Before the fix: new test **5 passed / 8 failed**.
- After the fix: **13 passed / 0 failed**.

Full-suite before/after in an isolated environment (identical command, only `nodes/basic.py` swapped):
- pristine upstream `basic.py`: **61 failed / 269 passed**
- patched `basic.py`: **53 failed / 277 passed**
- the patched run introduces **zero** new failures; the only delta is those 8 new slot cases flipping fail → pass. The other failures / collection errors are identical on both runs — they are pre-existing and environmental (they need the running ComfyUI `server` / `folder_paths` and optional ASR dependencies such as whisper, which an isolated test process does not have), and are unrelated to this change.

Also verified end-to-end: a 2-second 832×480 image-to-video run with `@image1` now resolves to i2v and its extracted first frame matches the supplied reference image.

### Notes for reviewers

- The tuple shape is not hypothetical: it is what `is_input_list` + `lazy` hands the node at runtime on ComfyUI 0.33.0.
- The fix is intentionally minimal and container-shape-only; empty-slot placeholder filtering and slot-number semantics are left untouched.