### PR TITLE
fix: phase-align H3 context encoding and reuse newly rendered clips

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -98,7 +98,6 @@ class EasyMediaExtension(ComfyExtension):
             EasyH3SegmentSamplingStart,
             EasyH3SegmentSaveEnd,
             EasyH3ContextMediaTrim,
-            EasyH3ContextVideoEncodeTrim,
             EasyH3AudioContextLatent,
             EasyH3LockedAudioDurationAlign,
             EasyH3ProjectArtifact,

--- a/__init__.py
+++ b/__init__.py
@@ -98,6 +98,7 @@ class EasyMediaExtension(ComfyExtension):
             EasyH3SegmentSamplingStart,
             EasyH3SegmentSaveEnd,
             EasyH3ContextMediaTrim,
+            EasyH3ContextVideoEncodeTrim,
             EasyH3AudioContextLatent,
             EasyH3LockedAudioDurationAlign,
             EasyH3ProjectArtifact,

--- a/nodes/minimax.py
+++ b/nodes/minimax.py
@@ -218,10 +218,13 @@ def _h3_encode_context_media(
 ) -> Any:
     """Encode a phase-aligned video suffix and the delivered audio timeline."""
     video_tail = graph.node(
-        "easy h3ContextVideoEncodeTrim",
-        id=f"{node_prefix}_video_trim",
+        "easy h3ContextMediaTrim",
+        id=f"{node_prefix}_encode_trim",
         images=images,
-        context_frames=int(context_frames),
+        audio=audio,
+        trim_frames=0,
+        output_frames=int(context_frames),
+        phase_align_video_encode=True,
     )
     encoded_video = graph.node(
         "VAEEncode",
@@ -232,7 +235,7 @@ def _h3_encode_context_media(
     encoded_audio = graph.node(
         "VAEEncodeAudio",
         id=f"{node_prefix}_audio_encode",
-        audio=audio,
+        audio=video_tail.out(1),
         vae=audio_vae,
     )
     return graph.node(
@@ -1230,6 +1233,7 @@ class EasyH3ContextMediaTrim(io.ComfyNode):
                 io.Int.Input("trim_frames", min=0),
                 io.Int.Input("output_frames", min=1),
                 io.Boolean.Input("pad_audio", default=True),
+                io.Boolean.Input("phase_align_video_encode", default=False),
                 io.Float.Input(
                     "fps",
                     default=24.0,
@@ -1253,10 +1257,20 @@ class EasyH3ContextMediaTrim(io.ComfyNode):
         trim_frames: int = 0,
         output_frames: int = 1,
         pad_audio: bool = True,
+        phase_align_video_encode: bool = False,
         fps: float = 24.0,
     ) -> io.NodeOutput:
         prefix = max(0, int(trim_frames))
         wanted_frames = max(1, int(output_frames))
+        if bool(phase_align_video_encode):
+            if not isinstance(images, torch.Tensor) or images.ndim != 4:
+                raise ValueError("images must have IMAGE shape [B, H, W, C]")
+            start = h3_phase_aligned_context_start(
+                int(images.shape[0]),
+                wanted_frames,
+            )
+            return io.NodeOutput(images[start:].contiguous(), audio)
+
         frame_rate = float(fps)
         if not math.isfinite(frame_rate) or frame_rate <= 0:
             raise ValueError("fps must be a positive finite number")
@@ -1292,42 +1306,6 @@ class EasyH3ContextMediaTrim(io.ComfyNode):
             images[prefix : prefix + wanted_frames] if images is not None else None,
             {"waveform": output_waveform, "sample_rate": sample_rate},
         )
-
-
-class EasyH3ContextVideoEncodeTrim(io.ComfyNode):
-    """Keep the smallest H3 VAE chunk-aligned suffix containing the context."""
-
-    @classmethod
-    def define_schema(cls) -> io.Schema:
-        return io.Schema(
-            node_id="easy h3ContextVideoEncodeTrim",
-            display_name="H3 Context Video Encode Trim",
-            category="_EasyUse/H3",
-            description=(
-                "Internal H3 frame slicer that preserves the original 17-frame "
-                "video VAE chunk phase while avoiding full-clip re-encoding."
-            ),
-            inputs=[
-                io.Image.Input("images"),
-                io.Int.Input("context_frames", default=22, min=1),
-            ],
-            outputs=[io.Image.Output("images")],
-            is_dev_only=True,
-        )
-
-    @classmethod
-    def execute(
-        cls,
-        images: torch.Tensor,
-        context_frames: int = 22,
-    ) -> io.NodeOutput:
-        if not isinstance(images, torch.Tensor) or images.ndim != 4:
-            raise ValueError("images must have IMAGE shape [B, H, W, C]")
-        start = h3_phase_aligned_context_start(
-            int(images.shape[0]),
-            int(context_frames),
-        )
-        return io.NodeOutput(images[start:].contiguous())
 
 
 class EasyH3LockedAudioDurationAlign(io.ComfyNode):

--- a/nodes/minimax.py
+++ b/nodes/minimax.py
@@ -47,6 +47,7 @@ from ..utils.models import detect_turbo_lora_from_prompt, detect_turbo_model
 from ..utils.minimax import (
     expand_image_inputs,
     flatten_media_inputs,
+    h3_phase_aligned_context_start,
     remove_output_files_by_prefix,
 )
 
@@ -213,12 +214,19 @@ def _h3_encode_context_media(
     vae: Any,
     audio_vae: Any,
     node_prefix: str,
+    context_frames: int = 22,
 ) -> Any:
-    """Encode an already-trimmed clip into a clean H3 AV context latent."""
+    """Encode a phase-aligned video suffix and the delivered audio timeline."""
+    video_tail = graph.node(
+        "easy h3ContextVideoEncodeTrim",
+        id=f"{node_prefix}_video_trim",
+        images=images,
+        context_frames=int(context_frames),
+    )
     encoded_video = graph.node(
         "VAEEncode",
         id=f"{node_prefix}_video_encode",
-        pixels=images,
+        pixels=video_tail.out(0),
         vae=vae,
     )
     encoded_audio = graph.node(
@@ -1065,7 +1073,13 @@ class EasyH3ProjectContextLatentLoad(io.ComfyNode):
 def _timed_h3_project_graph(graph: GraphBuilder, project_name: str) -> dict[str, Any]:
     """Tag native operations for timing without changing node types or inputs."""
     expanded = graph.finalize()
-    timed_types = {"SamplerCustomAdvanced", "VAEDecode", "VAEDecodeAudio"}
+    timed_types = {
+        "SamplerCustomAdvanced",
+        "VAEEncode",
+        "VAEEncodeAudio",
+        "VAEDecode",
+        "VAEDecodeAudio",
+    }
     for node_id, node in expanded.items():
         if node["class_type"] not in timed_types:
             continue
@@ -1278,6 +1292,42 @@ class EasyH3ContextMediaTrim(io.ComfyNode):
             images[prefix : prefix + wanted_frames] if images is not None else None,
             {"waveform": output_waveform, "sample_rate": sample_rate},
         )
+
+
+class EasyH3ContextVideoEncodeTrim(io.ComfyNode):
+    """Keep the smallest H3 VAE chunk-aligned suffix containing the context."""
+
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="easy h3ContextVideoEncodeTrim",
+            display_name="H3 Context Video Encode Trim",
+            category="_EasyUse/H3",
+            description=(
+                "Internal H3 frame slicer that preserves the original 17-frame "
+                "video VAE chunk phase while avoiding full-clip re-encoding."
+            ),
+            inputs=[
+                io.Image.Input("images"),
+                io.Int.Input("context_frames", default=22, min=1),
+            ],
+            outputs=[io.Image.Output("images")],
+            is_dev_only=True,
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        images: torch.Tensor,
+        context_frames: int = 22,
+    ) -> io.NodeOutput:
+        if not isinstance(images, torch.Tensor) or images.ndim != 4:
+            raise ValueError("images must have IMAGE shape [B, H, W, C]")
+        start = h3_phase_aligned_context_start(
+            int(images.shape[0]),
+            int(context_frames),
+        )
+        return io.NodeOutput(images[start:].contiguous())
 
 
 class EasyH3LockedAudioDurationAlign(io.ComfyNode):

--- a/tests/test_h3_project.py
+++ b/tests/test_h3_project.py
@@ -515,6 +515,7 @@ def test_compose_h3_project_video_uses_selected_file_for_same_index(monkeypatch,
         "video": alternate.name,
         "locked_audio": alternate_audio.name,
     }
+    manifest["segments"]["0"]["updated_at"] = 100.0
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     monkeypatch.setattr("utils.h3_project.folder_paths.get_output_directory", lambda: str(tmp_path))
     monkeypatch.setattr("utils.video.ffprobe_info", lambda _path: {"frame_count": 120})
@@ -530,6 +531,7 @@ def test_compose_h3_project_video_uses_selected_file_for_same_index(monkeypatch,
         "clips": [{
             "index": 0,
             "file_path": str(alternate.relative_to(tmp_path)),
+            "updated_at": 100.0,
             "source_start_frame": 0,
             "source_end_frame": 120,
         }],
@@ -538,6 +540,58 @@ def test_compose_h3_project_video_uses_selected_file_for_same_index(monkeypatch,
     assert captured["segments"][0]["source"] == str(alternate)
     assert captured["segments"][0]["audio_locked"] is True
     assert captured["segments"][0]["audio_source"] == str(alternate_audio)
+
+
+def test_compose_h3_project_video_uses_generation_written_after_snapshot(
+    monkeypatch,
+    tmp_path,
+):
+    project_dir = _write_render_project(tmp_path)
+    manifest_path = project_dir / "project.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["segments"]["1"]["updated_at"] = 100.0
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setattr(
+        "utils.h3_project.folder_paths.get_output_directory",
+        lambda: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "utils.video.ffprobe_info",
+        lambda _path: {"frame_count": 120},
+    )
+    snapshot = load_h3_project_data("demo")
+    snapshot["clips"][1] = {
+        **snapshot["clips"][1],
+        "source_start_frame": 10,
+        "source_end_frame": 70,
+    }
+
+    replacement = project_dir / "video_1_2.mp4"
+    replacement.write_bytes(b"new-video-1")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["segments"]["1"]["generations"]["2"] = {
+        "video": replacement.name,
+        "updated_at": 200.0,
+    }
+    manifest["segments"]["1"]["active_generation"] = 2
+    manifest["segments"]["1"]["updated_at"] = 200.0
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    captured = {}
+
+    def fake_merge(segments, total_length, frame_rate, width, height):
+        captured.update({"segments": segments, "total_length": total_length})
+        return str(tmp_path / "combined.mp4")
+
+    monkeypatch.setattr(
+        "utils.video.merge_video_track_with_ffmpeg",
+        fake_merge,
+    )
+
+    compose_h3_project_video("demo", snapshot)
+
+    assert Path(captured["segments"][1]["source"]).name == replacement.name
+    assert captured["segments"][1]["source_start_frame"] == 10
+    assert captured["total_length"] == 180
 
 
 def test_compose_h3_project_video_uses_trimmed_sequential_segments(monkeypatch, tmp_path):

--- a/tests/test_h3_project.py
+++ b/tests/test_h3_project.py
@@ -330,7 +330,27 @@ def test_generation_uses_free_slot_then_replaces_oldest_at_limit(tmp_path):
         os.utime(path, (modified, modified))
 
     assert choose_h3_generation(tmp_path, 2, False) == 1
-    assert choose_h3_generation(tmp_path, 2, True) == 1
+    assert choose_h3_generation(tmp_path, 2, True) == 10
+
+
+def test_override_generation_targets_latest_saved_video(tmp_path):
+    (tmp_path / "video_2_1.mp4").write_text("older")
+    (tmp_path / "video_2_2.mp4").write_text("newer")
+    os.utime(tmp_path / "video_2_1.mp4", (1000, 1000))
+    os.utime(tmp_path / "video_2_2.mp4", (2000, 2000))
+    (tmp_path / "project.json").write_text(json.dumps({
+        "segments": {
+            "2": {
+                "active_generation": 1,
+                "generations": {
+                    "1": {"video": "video_2_1.mp4"},
+                    "2": {"video": "video_2_2.mp4"},
+                },
+            },
+        },
+    }))
+
+    assert choose_h3_generation(tmp_path, 2, True) == 2
 
 
 def _write_render_project(tmp_path: Path) -> Path:

--- a/tests/test_minimax_node.py
+++ b/tests/test_minimax_node.py
@@ -767,7 +767,7 @@ def test_h3_context_media_trim_can_leave_locked_audio_short_for_alignment(
     ("total_frames", "expected_start"),
     [(22, 0), (120, 102), (124, 102), (240, 221)],
 )
-def test_h3_context_video_encode_trim_preserves_vae_chunk_phase(
+def test_h3_context_media_trim_preserves_vae_chunk_phase_for_encoding(
     monkeypatch,
     total_frames,
     expected_start,
@@ -776,16 +776,24 @@ def test_h3_context_video_encode_trim_preserves_vae_chunk_phase(
     images = torch.arange(total_frames, dtype=torch.float32).reshape(
         total_frames, 1, 1, 1
     )
+    audio = {
+        "waveform": torch.zeros(1, 1, total_frames * 2),
+        "sample_rate": 48,
+    }
 
-    result = module.EasyH3ContextVideoEncodeTrim.execute(
+    result = module.EasyH3ContextMediaTrim.execute(
         images,
-        context_frames=22,
+        audio,
+        trim_frames=0,
+        output_frames=22,
+        phase_align_video_encode=True,
     )
 
-    output = result.values[0]
-    assert output[:, 0, 0, 0].tolist() == list(
+    output_images, output_audio = result.values
+    assert output_images[:, 0, 0, 0].tolist() == list(
         range(expected_start, total_frames)
     )
+    assert output_audio is audio
 
 
 def test_h3_locked_audio_duration_align_matches_decoded_video_without_padding(
@@ -2147,11 +2155,14 @@ def test_multitrack_h3_dual_context_uses_separate_low_and_hires_latents(monkeypa
         video_trim = result.expand[video_encode["inputs"]["pixels"][0]]
         audio_encode = result.expand[concat["inputs"]["audio_latent"][0]]
         assert video_encode["class_type"] == "VAEEncode"
-        assert video_trim["class_type"] == "easy h3ContextVideoEncodeTrim"
-        assert video_trim["inputs"]["context_frames"] == 22
+        assert video_trim["class_type"] == "easy h3ContextMediaTrim"
+        assert video_trim["inputs"]["output_frames"] == 22
+        assert video_trim["inputs"]["phase_align_video_encode"] is True
         assert audio_encode["class_type"] == "VAEEncodeAudio"
-        audio_source = result.expand[audio_encode["inputs"]["audio"][0]]
-        assert audio_source["class_type"] != "easy h3ContextVideoEncodeTrim"
+        assert audio_encode["inputs"]["audio"] == [
+            video_encode["inputs"]["pixels"][0],
+            1,
+        ]
 
 
 def test_multitrack_h3_connected_second_pass_sampling_overrides_context_preset(

--- a/tests/test_minimax_node.py
+++ b/tests/test_minimax_node.py
@@ -2610,7 +2610,7 @@ def test_h3_project_artifact_preserves_complete_first_pass_checkpoint(
         assert audio.shape[-1] == 65
 
 
-def test_h3_project_artifact_override_reuses_generation_one(monkeypatch, tmp_path):
+def test_h3_project_artifact_override_reuses_latest_generation(monkeypatch, tmp_path):
     module = _load_minimax_node(monkeypatch)
     assert module is not None
     monkeypatch.setattr(
@@ -2622,27 +2622,34 @@ def test_h3_project_artifact_override_reuses_generation_one(monkeypatch, tmp_pat
     project_dir = tmp_path / "easy_media" / "projects" / "default"
     project_dir.mkdir(parents=True)
 
-    for run in range(2):
+    for run, project_save in enumerate(("new", "new", "override")):
         staged = project_dir / f".override_{run}.mp4"
         staged.write_bytes(f"video-{run}".encode())
         module.EasyH3ProjectArtifact.execute(
             project_name="",
-            project_save="override",
+            project_save=project_save,
             segment_index=3,
             context_latent=_h3_context_latent(run),
             video_path=f"output/{staged.relative_to(tmp_path)}",
             tracks_info=info,
         )
 
-    assert [path.name for path in project_dir.glob("video_3_*.mp4")] == [
-        "video_3_1.mp4"
+    assert sorted(path.name for path in project_dir.glob("video_3_*.mp4")) == [
+        "video_3_1.mp4",
+        "video_3_2.mp4",
     ]
+    assert (project_dir / "video_3_1.mp4").read_bytes() == b"video-0"
+    assert (project_dir / "video_3_2.mp4").read_bytes() == b"video-2"
     assert not list(project_dir.glob("latent_3_*"))
-    assert [
+    assert sorted(
         path.name for path in project_dir.glob("context_latent_3_*.safetensors")
-    ] == [
-        "context_latent_3_1.safetensors"
+    ) == [
+        "context_latent_3_1.safetensors",
+        "context_latent_3_2.safetensors",
     ]
+    manifest = json.loads((project_dir / "project.json").read_text())
+    assert manifest["segments"]["3"]["active_generation"] == 2
+    assert set(manifest["segments"]["3"]["generations"]) == {"1", "2"}
 
 
 @pytest.mark.parametrize("project_save", ["new", "override"])

--- a/tests/test_minimax_node.py
+++ b/tests/test_minimax_node.py
@@ -763,6 +763,31 @@ def test_h3_context_media_trim_can_leave_locked_audio_short_for_alignment(
     assert result.values[1]["waveform"].shape[-1] == 8
 
 
+@pytest.mark.parametrize(
+    ("total_frames", "expected_start"),
+    [(22, 0), (120, 102), (124, 102), (240, 221)],
+)
+def test_h3_context_video_encode_trim_preserves_vae_chunk_phase(
+    monkeypatch,
+    total_frames,
+    expected_start,
+):
+    module = _load_minimax_node(monkeypatch)
+    images = torch.arange(total_frames, dtype=torch.float32).reshape(
+        total_frames, 1, 1, 1
+    )
+
+    result = module.EasyH3ContextVideoEncodeTrim.execute(
+        images,
+        context_frames=22,
+    )
+
+    output = result.values[0]
+    assert output[:, 0, 0, 0].tolist() == list(
+        range(expected_start, total_frames)
+    )
+
+
 def test_h3_locked_audio_duration_align_matches_decoded_video_without_padding(
     monkeypatch,
 ):
@@ -2115,6 +2140,18 @@ def test_multitrack_h3_dual_context_uses_separate_low_and_hires_latents(monkeypa
     )
     assert result.expand[low_context_link[0]]["class_type"] == "LTXVConcatAVLatent"
     assert hires_context_link != low_context_link
+    context_concat_links = [hires_trim["inputs"]["latent"], low_context_link]
+    for concat_link in context_concat_links:
+        concat = result.expand[concat_link[0]]
+        video_encode = result.expand[concat["inputs"]["video_latent"][0]]
+        video_trim = result.expand[video_encode["inputs"]["pixels"][0]]
+        audio_encode = result.expand[concat["inputs"]["audio_latent"][0]]
+        assert video_encode["class_type"] == "VAEEncode"
+        assert video_trim["class_type"] == "easy h3ContextVideoEncodeTrim"
+        assert video_trim["inputs"]["context_frames"] == 22
+        assert audio_encode["class_type"] == "VAEEncodeAudio"
+        audio_source = result.expand[audio_encode["inputs"]["audio"][0]]
+        assert audio_source["class_type"] != "easy h3ContextVideoEncodeTrim"
 
 
 def test_multitrack_h3_connected_second_pass_sampling_overrides_context_preset(
@@ -3307,17 +3344,40 @@ def test_audio_project_preflight_does_not_block_other_projects_or_video(monkeypa
 def test_project_timing_keeps_native_nodes_and_inputs(monkeypatch):
     module = _load_minimax_node(monkeypatch)
     module.comfy_nodes.NODE_CLASS_MAPPINGS["ImageResizeKJv2"] = _ImageResizeKJWithNvidia
-    inputs = _h3_project_inputs(project_name="timing-demo", sampling_mode=_h3_sampling_mode("dual"))
+    inputs = _h3_project_inputs(
+        project_name="timing-demo",
+        sampling_mode=_h3_sampling_mode("dual"),
+    )
+    inputs["tracks_info"][0]["tracks"][0]["segments"].append({
+        "start_frame": 120,
+        "end_frame": 240,
+        "content": {
+            "task_mode": "l2v",
+            "continuity_mode": "context",
+            "images": [],
+            "user_prompt": "continue",
+        },
+    })
     module.GraphBuilder.set_default_prefix("timing", 0, 0)
     result = module.EasyMultiTrackProject.execute(**inputs)
     tagged = [node for node in result.expand.values() if "easy_media_timing" in node.get("_meta", {})]
     assert len(tagged) >= 5
-    assert {node["class_type"] for node in tagged} == {"SamplerCustomAdvanced", "VAEDecode", "VAEDecodeAudio"}
+    assert {node["class_type"] for node in tagged} == {
+        "SamplerCustomAdvanced",
+        "VAEEncode",
+        "VAEEncodeAudio",
+        "VAEDecode",
+        "VAEDecodeAudio",
+    }
     labels = [node["_meta"]["easy_media_timing"] for node in tagged]
     assert len(set(labels)) == len(labels)
     assert all(label.startswith("timing-demo / ") for label in labels)
     assert any("first_pass_sample_0" in label for label in labels)
     assert any("second_pass_sample_0" in label for label in labels)
+    assert any("hires_context_1_video_encode" in label for label in labels)
+    assert any("hires_context_1_audio_encode" in label for label in labels)
+    assert any("low_context_1_video_encode" in label for label in labels)
+    assert any("low_context_1_audio_encode" in label for label in labels)
 
     monkeypatch.setattr(module, "_timed_h3_project_graph", lambda graph, _name: graph.finalize())
     module.GraphBuilder.set_default_prefix("timing", 0, 0)

--- a/tests/test_minimax_utils.py
+++ b/tests/test_minimax_utils.py
@@ -1,6 +1,7 @@
 import importlib.util
 from pathlib import Path
 
+import pytest
 import torch
 
 
@@ -29,3 +30,59 @@ def test_expand_image_inputs_flattens_batches_and_nested_lists():
 
     assert [image.item() for image in images] == [0.0, 1.0, 2.0]
     assert all(image.shape == (1, 1, 1, 1) for image in images)
+
+
+@pytest.mark.parametrize(
+    ("total_frames", "context_frames", "expected_start"),
+    [
+        (22, 22, 0),
+        (120, 22, 102),
+        (124, 22, 102),
+        (240, 22, 221),
+        (120, 39, 85),
+    ],
+)
+def test_h3_phase_aligned_context_start_preserves_encoder_chunk_phase(
+    total_frames,
+    context_frames,
+    expected_start,
+):
+    module = _load_minimax_utils()
+
+    assert module.h3_phase_aligned_context_start(
+        total_frames,
+        context_frames,
+    ) == expected_start
+
+
+@pytest.mark.parametrize("total_frames", [22, 120, 124, 240])
+def test_h3_phase_aligned_suffix_matches_full_encode_tail(total_frames):
+    module = _load_minimax_utils()
+
+    def encode_chunk_signatures(first_frame, frame_count):
+        signatures = []
+        chunk_size = module.H3_VAE_FRAME_CHUNK
+        for offset in range(0, frame_count, chunk_size):
+            chunk_start = first_frame + offset
+            chunk_end = min(first_frame + frame_count, chunk_start + chunk_size)
+            chunk = tuple(range(chunk_start, chunk_end))
+            padded_chunk = chunk + (chunk[-1],) * (chunk_size - len(chunk))
+            signatures.extend(
+                (padded_chunk, token_index)
+                for token_index in range(module.H3_VAE_TOKENS_PER_CHUNK)
+            )
+        return signatures[:-module.H3_VAE_FINAL_TOKEN_DROP]
+
+    start = module.h3_phase_aligned_context_start(total_frames, 22)
+    full = encode_chunk_signatures(0, total_frames)
+    suffix = encode_chunk_signatures(start, total_frames - start)
+
+    assert suffix == full[-7:]
+
+
+@pytest.mark.parametrize("context_frames", [0, 6, 121])
+def test_h3_phase_aligned_context_start_rejects_invalid_context(context_frames):
+    module = _load_minimax_utils()
+
+    with pytest.raises(ValueError):
+        module.h3_phase_aligned_context_start(120, context_frames)

--- a/utils/h3_project.py
+++ b/utils/h3_project.py
@@ -937,6 +937,7 @@ def _h3_project_data(
             "source_start_frame": 0,
             "source_end_frame": active_file["source_frame_count"],
             "source_frame_count": active_file["source_frame_count"],
+            "updated_at": float(segment.get("updated_at", 0) or 0),
             "continuity_mode": (
                 "context" if str(segment.get("continuity_mode", "shot")).lower() == "context" else "shot"
             ),
@@ -1021,20 +1022,36 @@ def compose_h3_project_video(project_name: Any, project_data: Any = None) -> Pat
             # failing an otherwise valid render containing newly generated clips.
             continue
         requested_path = str(clip.get("file_path", ""))
-        selected_file = next(
+        snapshot_updated_at = clip.get("updated_at")
+        if snapshot_updated_at is None and isinstance(requested, dict):
+            snapshot_updated_at = requested.get("updated_at")
+        try:
+            regenerated_after_snapshot = (
+                snapshot_updated_at is not None
+                and float(source_clip.get("updated_at", 0) or 0)
+                > float(snapshot_updated_at)
+            )
+        except (TypeError, ValueError, OverflowError):
+            regenerated_after_snapshot = False
+        active_file = next(
             (
                 file
                 for file in source_clip.get("video_files", [])
-                if file.get("file_path") == requested_path
+                if file.get("file_path") == source_clip.get("file_path")
             ),
-            next(
+            source_clip,
+        )
+        selected_file = (
+            active_file
+            if regenerated_after_snapshot
+            else next(
                 (
                     file
                     for file in source_clip.get("video_files", [])
-                    if file.get("file_path") == source_clip.get("file_path")
+                    if file.get("file_path") == requested_path
                 ),
-                source_clip,
-            ),
+                active_file,
+            )
         )
         source_count = int(selected_file["source_frame_count"])
         try:

--- a/utils/h3_project.py
+++ b/utils/h3_project.py
@@ -460,8 +460,6 @@ def safe_h3_project_name(value: Any) -> str:
 
 
 def choose_h3_generation(project_dir: Path, segment_index: int, override: bool) -> int:
-    if override:
-        return 1
     versions: dict[int, float] = {}
     pattern = re.compile(
         rf"^(?:video|audio|locked_audio|context_latent(?:_low)?)_{int(segment_index)}_"
@@ -482,6 +480,12 @@ def choose_h3_generation(project_dir: Path, segment_index: int, override: bool) 
                     modified,
                     versions.get(generation, modified),
                 )
+    if override:
+        return (
+            max(versions, key=lambda generation: (versions[generation], generation))
+            if versions
+            else 1
+        )
     for generation in range(1, H3_PROJECT_VERSION_LIMIT + 1):
         if generation not in versions:
             return generation

--- a/utils/minimax.py
+++ b/utils/minimax.py
@@ -6,6 +6,51 @@ from typing import Any
 import torch
 
 
+H3_VAE_FRAME_CHUNK = 17
+H3_VAE_TOKENS_PER_CHUNK = 5
+H3_VAE_FINAL_TOKEN_DROP = 3
+H3_FRAMES_PER_TOKEN = (1, 4, 4, 4, 4)
+
+
+def h3_phase_aligned_context_start(
+    total_frames: int,
+    context_frames: int = 22,
+) -> int:
+    """Return the first frame of the smallest phase-aligned H3 VAE suffix."""
+    frame_count = int(total_frames)
+    requested_frames = int(context_frames)
+    if frame_count < 1:
+        raise ValueError("total_frames must be positive")
+    if requested_frames < 1 or requested_frames > frame_count:
+        raise ValueError(
+            "context_frames must be positive and no greater than total_frames"
+        )
+
+    latent_steps = 0
+    covered_frames = 0
+    while covered_frames < requested_frames:
+        covered_frames += H3_FRAMES_PER_TOKEN[
+            latent_steps % len(H3_FRAMES_PER_TOKEN)
+        ]
+        latent_steps += 1
+    if covered_frames != requested_frames:
+        raise ValueError(
+            "context_frames must align to the H3 temporal latent grid"
+        )
+
+    required_chunks = (
+        latent_steps
+        + H3_VAE_FINAL_TOKEN_DROP
+        + H3_VAE_TOKENS_PER_CHUNK
+        - 1
+    ) // H3_VAE_TOKENS_PER_CHUNK
+    available_chunks = (
+        frame_count + H3_VAE_FRAME_CHUNK - 1
+    ) // H3_VAE_FRAME_CHUNK
+    first_chunk = max(0, available_chunks - required_chunks)
+    return first_chunk * H3_VAE_FRAME_CHUNK
+
+
 def remove_output_files_by_prefix(
     output_directory: str | Path,
     filename_path: str,


### PR DESCRIPTION
## Summary

This PR fixes H3 context encoding so the encoded video tail stays phase-aligned with the full-length H3 VAE chunk grid, and reuses the most recently rendered generation when a segment is overridden.

### Phase-aligned context encoding

- Adds `h3_phase_aligned_context_start()` in `utils/minimax.py`, which computes the first frame of the smallest VAE chunk-aligned suffix (17-frame chunks, 5 tokens per chunk, final 3 tokens dropped).
- Adds a `phase_align_video_encode` input to `EasyH3ContextMediaTrim` so the trim node slices the image tail from the computed start frame before encoding.
- Reuses `easy h3ContextMediaTrim` inside `_h3_encode_context_media` to encode only the aligned 22-frame suffix for both video and audio.
- Includes `VAEEncode`/`VAEEncodeAudio` in the H3 project timing instrumentation.

### Override generation handling

- `choose_h3_generation` now returns the latest generation by modification time for override runs instead of always returning generation `1`.
- `compose_h3_project_video` uses `updated_at` timestamps to pick a clip regenerated after the snapshot; otherwise it falls back to the file requested in the snapshot.

## Test plan

- Added unit tests for the phase-aligned start frame across several total-frame counts and for the aligned suffix matching the full encode tail.
- Added tests for override generation selection targeting the latest saved video, and for combining a clip generated after the snapshot.
- Updated existing H3 artifact/timing tests to cover the new encode timing labels and override behavior.

Existing test suite passes locally.